### PR TITLE
SEASK-90 EPPPowerBIReportStarterKit.QuickStartAMI Pre-Release & Release Teamcity code move to Powershell file

### DIFF
--- a/teamcity/Invoke-AMIImage.ps1
+++ b/teamcity/Invoke-AMIImage.ps1
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+.description
+    Setup new AWS Image under 'Ed-Fi-EPP-Starter-Kit' Name
+.parameter awsPublicImageName
+    Public Image Name for Ed-Fi-EPP-Starter-Kit
+.parameter awsS3KeyName
+    S3 Key Name for EPPPower BI Report StarterKit QuickStart VM
+#>
+
+param(
+    [string] $awsPublicImageName = 'Ed-Fi-EPP-Starter-Kit',
+    [string] $awsS3KeyName = 'EPPPowerBIReportStarterKitQuickStartVM'
+)
+
+Import-Module -Force -Scope Global  "$PSScriptRoot/TaskHelper.psm1"
+
+$global:awsNewImageId = $null
+
+function Remove-OldPrivateImage {
+
+    param(
+        [Parameter(Mandatory = $true)]  [string] $awsPublicImageName
+    )
+
+    $ErrorActionPreference = 'Stop'
+    $oldPrivateImageId =(& aws ec2 describe-images --filters "Name=name,Values=$awsPublicImageName" "Name=is-public,Values=false"  "Name=owner-id,Values=258274856018"  --query "Images[*].ImageId" --output text)
+
+    if($null -ne $oldPrivateImageId) {
+
+        Write-Host "Old Private Image Id "$oldPrivateImageId
+
+        $snapShotId =(& aws ec2 describe-images --filters "Name=name,Values=$awsPublicImageName" "Name=is-public,Values=false"  "Name=owner-id,Values=258274856018"  --query "Images[*].BlockDeviceMappings[*].Ebs.SnapshotId"  --output text)
+        Write-Host "Old Private Image SnapShot Id " $snapShotId
+
+        aws ec2 deregister-image --image-id $oldPrivateImageId
+        Write-Host "The Old Private Image " $oldPrivateImageId "has been deleted successfully!"
+
+        if($null -ne $snapShotId) {
+          aws ec2 delete-snapshot --snapshot-id $snapShotId
+          Write-Host "The Old Private Image SnapShot " $snapShotId "has been deleted successfully!"
+        }
+    }
+    else
+    {
+        Write-Host "There is no old Private Image exist now."
+    }
+}
+
+function Import-AMIImage {
+    param(
+        [Parameter(Mandatory = $true)]  [string] $awsPublicImageName,
+        [Parameter(Mandatory = $true)]  [string] $awsS3KeyName
+    )
+
+    $importTaskId =(& aws ec2 import-image --description "$awsPublicImageName-import" --disk-containers Description="$awsPublicImageName",Format="vhdx",UserBucket="{S3Bucket=edfi-starter-kits,S3Key=$awsS3KeyName/ed-fi-starter-kit.vhdx}" --query "ImportTaskId" --output text)
+    Write-Host " Original Import Image "$importTaskId " has been started.It will take a while to continue on next step. Please be patient. "
+
+    $isImportImageNotCompleted =$true
+    while($isImportImageNotCompleted -eq $true) {
+
+       Start-Sleep -s 10
+       $Iscompleted =(& aws ec2 describe-import-image-tasks --import-task-ids $importTaskId  --query "ImportImageTasks[*].Status" --output text)
+       if($Iscompleted -eq "completed") {
+            $isImportImageNotCompleted =$false
+            Write-Host " Original Import Image " $importTaskId "has been completed successfully! "
+       }
+
+     }
+
+     $originalImageId =(& aws ec2 describe-import-image-tasks  --import-task-ids $importTaskId  --query "ImportImageTasks[*].ImageId" --output text)
+
+     $originalSnapShotId =(& aws ec2 describe-import-image-tasks  --import-task-ids $importTaskId  --query "ImportImageTasks[*].SnapshotDetails[*].SnapshotId"  --output text)
+
+     $newimageId =(& aws ec2 copy-image --source-image-id $originalImageId  --source-region us-east-2 --region us-east-2 --name $awsPublicImageName --description $awsPublicImageName --query "ImageId" --output text)
+
+     $global:awsNewImageId = $newimageId
+     Write-Host "global New Image Id " $global:awsNewImageId
+     Write-Host "Copy to new Image " $newimageId " process has been started, It will take a while to complete this step, Basically adding name " $awsPublicImageName "to image"
+
+    $isNewImageNotAvailable =$true
+    while($isNewImageNotAvailable -eq $true) {
+
+       Start-Sleep -s 10
+       $IsAvailable =(& aws ec2 describe-images  --image-ids  $newimageId  --filters "Name=name,Values=$awsPublicImageName" "Name=state,Values=available" --query "Images[*].State"  --output text)
+       if($IsAvailable -eq "available") {
+            $isNewImageNotAvailable =$false
+            Write-Host " New Image " $newimageId "has been copied successfully!"
+       }
+
+     }
+
+    aws ec2 deregister-image --image-id $originalImageId
+    Write-Host "The original image " $originalImageId "has been deleted successfully!"
+
+    aws ec2 delete-snapshot --snapshot-id $originalSnapShotId
+}
+
+function Set-TagToAMI {
+
+    Write-Host "global New Image ID" $global:awsNewImageId
+    $newimageId = $global:awsNewImageId
+    aws ec2 create-tags --resources $newimageId  --tags Key=Schedule,Value=austin-office-hours
+    $instanceIdFromTag =(& aws ec2 describe-tags  --filters "Name=resource-id,Values= $newimageId" --query "Tags[*].ResourceId" --output text)
+    if($newimageId -eq $instanceIdFromTag){
+    Write-Host "New Tag with Key=Schedule,Value=austin-office-hours has been created successfully for this image " $newimageId
+    }
+
+}
+
+function Invoke-AMIImage {
+
+    $script:result = @()
+
+    $elapsed = Use-StopWatch {
+        try {
+            $script:result += Invoke-Task -name "Remove-OldPrivateImage" -task { Remove-OldPrivateImage  $awsPublicImageName}
+            $script:result += Invoke-Task -name "Import-AMIImage" -task { Import-AMIImage $awsPublicImageName $awsS3KeyName }
+            $script:result += Invoke-Task -name "Set-TagToAMI" -task { Set-TagToAMI  }
+        }
+        finally {}
+
+    }
+
+    Test-Error
+
+    $script:result += New-TaskResult -name '-' -duration '-'
+    $script:result += New-TaskResult -name $MyInvocation.MyCommand.Name -duration $elapsed.format
+    return $script:result | Format-Table
+}
+
+Invoke-AMIImage

--- a/teamcity/Set-AMIImageToRelease.ps1
+++ b/teamcity/Set-AMIImageToRelease.ps1
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+.description
+    publish private  AWS Image under 'Ed-Fi-EPP-Starter-Kit' Name to public image
+.parameter awsPublicImageName
+    Public Image Name for Ed-Fi-EPP-Starter-Kit
+#>
+
+param(
+    [string] $awsPublicImageName = 'Ed-Fi-EPP-Starter-Kit'
+)
+
+Import-Module -Force -Scope Global  "$PSScriptRoot/TaskHelper.psm1"
+
+
+function Set-AMIImageToPublic {
+    param(
+        [Parameter(Mandatory = $true)]  [string] $awsPublicImageName
+    )
+
+    $ErrorActionPreference = 'Stop'
+    $newimageId =(& aws ec2 describe-images --filters "Name=name,Values=$awsPublicImageName" "Name=is-public,Values=false"  "Name=owner-id,Values=258274856018"  --query "Images[*].ImageId" --output text)
+
+    if($null -ne $newimageId){
+        aws ec2 modify-image-attribute   --image-id $newimageId   --launch-permission "Add=[{Group=all}]"
+        $IsAvaialbleInPublic =(& aws ec2 describe-images  --image-ids $newimageId  --filters "Name=name,Values=$awsPublicImageName" "Name=state,Values=available" --query "Images[*].Public"  --output text)
+        if($IsAvaialbleInPublic){
+            Write-Host "Turn on  Public visibility for this image " $newimageId "and ready to use for public!"
+        }
+        else
+        {
+            Write-Host "Public visibility is not set to image  " $newimageId
+        }
+    }
+    else
+    {
+        Write-Host "There is no image available in %aws.PublicImageName% to deploy to public"
+        exit(1)
+    }
+}
+
+
+function Set-AMIImageToRelease {
+
+    $script:result = @()
+
+    $elapsed = Use-StopWatch {
+        try {
+            $script:result += Invoke-Task -name "Set-AMIImageToPublic" -task { Set-AMIImageToPublic  $awsPublicImageName}
+        }
+        finally {}
+
+    }
+
+    Test-Error
+
+    $script:result += New-TaskResult -name '-' -duration '-'
+    $script:result += New-TaskResult -name $MyInvocation.MyCommand.Name -duration $elapsed.format
+    return $script:result | Format-Table
+}
+
+Set-AMIImageToRelease

--- a/teamcity/TaskHelper.psm1
+++ b/teamcity/TaskHelper.psm1
@@ -1,0 +1,118 @@
+﻿# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+function Clear-Error {
+    $Error.Clear()
+    # artificially setting an automatic variable needs to be done at a global scope level
+    $global:LASTEXITCODE = 0
+}
+
+function Write-TaskInfo ([string] $name) {
+    Write-TeamCityBlockOpened $name
+    $border = ('-' * ($name.Length + 8))
+    Write-Host
+    Write-Host -ForegroundColor Cyan $border
+    Write-Host -ForegroundColor Cyan "    $name    "
+    Write-Host -ForegroundColor Cyan $border
+    Write-Host
+}
+
+function Get-DurationString([TimeSpan] $elapsed) {
+    $duration = ''
+    if ($elapsed.TotalMilliseconds -lt 1000.0) { return "$($elapsed.Milliseconds)ms" }
+    if ($elapsed.Hours -gt 0) { $duration += "$($elapsed.Hours)h" }
+    if ($elapsed.Minutes -gt 0) { $duration += "$($elapsed.Minutes)m" }
+    if ($elapsed.Seconds -gt 0) { $duration += "$($elapsed.Seconds)s" }
+    return $duration
+}
+function Use-StopWatch([scriptblock] $scriptblock) {
+    $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
+    . $scriptblock
+    $elapsed.Stop()
+    $elapsed | Add-Member -MemberType NoteProperty -Name 'duration' -Value (Get-DurationString $elapsed.Elapsed)
+    $elapsed | Add-Member -MemberType NoteProperty -Name 'format' -Value ('{0:mm\:ss\.ff}' -f $elapsed.Elapsed)
+    return $elapsed
+}
+
+function Test-ErrorVariable { return ($null -ne $Error -and $Error.count -gt 0) }
+
+function Test-LastExitCodeVariable { return ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) }
+
+function Test-TaskAlreadyInvoked([string] $name) {
+    if ($null -eq $global:InvokedTasks){ return $false }
+    return ($global:InvokedTasks | Where-Object Task -eq $name | Measure-Object).Count -gt 0
+}
+function Test-TeamCityVersion { return (Test-Path env:TEAMCITY_VERSION) }
+
+function Test-Error {
+    if (Test-ErrorVariable) { throw $Error }
+    if (Test-LastExitCodeVariable) { throw "Last operation had non-zero exit code: $LASTEXITCODE" }
+    # https://www.jetbrains.com/help/teamcity/powershell.html#PowerShell-ErrorHandling
+    if ((Test-TeamCityVersion) -and (Test-ErrorVariable -or Test-LastExitCodeVariable)) { exit $LASTEXITCODE }
+}
+
+function Write-TaskDuration ([string] $name, [string] $duration) {
+    Write-Host "$name done in $duration."
+    Write-TeamCityBlockClosed $name
+}
+
+function Write-TeamCityBlockOpened([string] $name) {
+    if (Test-TeamCityVersion) { Write-Host "##teamcity[blockOpened name='$name']" }
+}
+
+function Write-TeamCityBlockClosed([string] $name) {
+    if (Test-TeamCityVersion) { Write-Host "##teamcity[blockClosed name='$name']" }
+}
+
+function Write-TeamCityBuildStatus([string] $text) {
+    if (Test-TeamCityVersion) { Write-Host "##teamcity[buildStatus text='$text']" }
+}
+
+function New-TaskResult([string] $name, [string] $duration) {
+    return New-Object PSObject -property @{ Task = $name; Duration = $duration }
+}
+
+function Invoke-Task([string] $name, [scriptBlock] $task) {
+    Clear-Error
+
+    Write-TaskInfo $name
+
+    $elapsed = Use-StopWatch($task)
+
+    Test-Error
+
+    Write-TaskDuration $name $elapsed.duration
+
+    $result = New-TaskResult -name $name -duration $elapsed.format
+    
+    if ($null -eq $global:InvokedTasks){ $global:InvokedTasks = @() }
+    $global:InvokedTasks += $result
+
+    return $result
+}
+
+function Write-HashtableInfo([hashtable] $hashtable) {
+    ($hashtable).GetEnumerator() | Sort-Object -Property Name | Format-Table -HideTableHeaders -AutoSize -Wrap | Out-Host
+}
+
+function Write-InvocationInfo {
+    param(
+        [System.Object] $Invocation
+    )
+
+    # allows more list properties to be displayed (default = 4)
+    $global:FormatEnumerationLimit = 10
+
+    Write-Host $Invocation.MyCommand.Name
+    ($Invocation.BoundParameters).GetEnumerator() |
+        Sort-Object -Property Key |
+        Format-Table -HideTableHeaders -AutoSize -Wrap |
+        Out-Host
+}
+
+function Write-ErrorAndThenExit([string] $message) { Write-Error $message; exit -1 }
+
+function Write-Info([string] $message) { Write-Host $message -ForegroundColor Green }
+
+Export-ModuleMember -function * -Alias *


### PR DESCRIPTION
EPPPowerBIReportStarterKit.QuickStartAMI Pre-Release build is using Invoke-AMIImage.ps1 from the repo to create the new private AMI image

EPPPowerBIReportStarterKit.QuickStartAMI Release build is using Set-AMIImageToRelease.ps1 from the repo to create the publish public AMI image.  Note :  I didn't run this build of the same logic and also I don't publish new  public AMI image 